### PR TITLE
Make the master password derivation about 355% faster

### DIFF
--- a/KeePass.IO/KeePass.IO.csproj
+++ b/KeePass.IO/KeePass.IO.csproj
@@ -130,6 +130,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <HintPath>..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib.Portable, Version=0.86.0.51803, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.Portable.0.86.0.0003\lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid+Xamarin.iOS10\ICSharpCode.SharpZipLib.Portable.dll</HintPath>
       <Private>True</Private>

--- a/KeePass.IO/packages.config
+++ b/KeePass.IO/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.8.1" targetFramework="wp81" />
   <package id="SharpZipLib.Portable" version="0.86.0.0003" targetFramework="wp81" />
 </packages>


### PR DESCRIPTION
Make the master password derivation about 355% faster by using the Bouncy Castle library.

Tested on a Lumia 640 with a debug build for a db with 5 000 000 rounds :
- 03:38 with the previous method
- 01:01 with Bouncy Castle

Benchmarked on x86 (100 000 rounds, test ran 100 times) :
- 47s with the original WinPass method
- 10s with the KeePass desktop client method
- 8s with Bouncy Castle
